### PR TITLE
Added method coef_to_csv to class InsolverGLMWrapper

### DIFF
--- a/insolver/wrappers/glm.py
+++ b/insolver/wrappers/glm.py
@@ -205,7 +205,7 @@ class InsolverGLMWrapper(InsolverBaseWrapper, InsolverH2OExtension, InsolverCVHP
                 column = method()
 
                 if isinstance(column, dict):
-                    result = result.join(pd.Series(column, name=name), how='outer')
+                    result = result.join(Series(column, name=name), how='outer')
             except Exception as e:
                 # exception of class Exception usage justified because
                 # method self.coef_norm() can raise exception of that class


### PR DESCRIPTION
Added method `coef_to_csv` to class `InsolverGLMWrapper` to write GLM coefficients to a comma-separated values (csv) file.

In new method I use `coef()` and `coef_norm()` methods which  can crash if model has not been fitted, and this behavior is not handled by  method `coef_to_csv`. I suppose this behavior should be handled in above methods.