### PR TITLE
Check is fitted glm coef funcs

### DIFF
--- a/insolver/wrappers/glm.py
+++ b/insolver/wrappers/glm.py
@@ -116,6 +116,8 @@ class InsolverGLMWrapper(InsolverBaseWrapper, InsolverH2OExtension, InsolverCVHP
         Returns:
             array: Returns predicted values.
         """
+        if not self.__is_fitted():
+            raise Exception("This instance is not fitted yet. Call 'fit' before using this estimator.")
         if (self.backend == 'sklearn') & isinstance(self.model, Pipeline):
             predictions = self.model.predict(X if not hasattr(self.model, 'feature_name_')
                                              else X[self.model.feature_name_])


### PR DESCRIPTION
В класс `InsolverGLMWrapper` в методы `coef` и `coef_norm` добавил проверку на то что модель была зафичина.
Для этого в класс `InsolverGLMWrapper` добавил метод `__is_fitted`.

Обратил внимание что по всему классу используется проверка на соответсвие инстанса модели определенному типу (почти в каждой функции). Пример для sklearn:
```
if (self.backend == 'sklearn') & isinstance(self.model, Pipeline)
```
также добавил эту проверку в `__is_fitted` и из-за чего он стал немного перегруженым. Обязательно ли делать данную проверку?